### PR TITLE
Add protocol and port environment variables

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -29,8 +29,10 @@ APP_ENV="prod"
 APP_SECRET="thisisaplaceholdersecret"
 ###< symfony/framework-bundle ###
 
-# DOMAIN is used to generate urls
+# Base URL information
+PROTOCOL="http"
 DOMAIN="localhost"
+PORT=""
 
 # LANG is the default language of the API
 LANG="en_US"

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -3,7 +3,9 @@
 parameters:
   lang: '%env(resolve:LANG)%'
   version: '%env(resolve:VERSION)%'
+  protocol: '%env(resolve:PROTOCOL)%'
   domain: '%env(resolve:DOMAIN)%'
+  port: '%env(resolve:PORT)%'
   app_env: '%env(resolve:APP_ENV)%'
   allow.upload.image: '%env(resolve:ALLOW_IMAGE_UPLOAD)%'
   allow.upload.video: '%env(resolve:ALLOW_VIDEO_UPLOAD)%'
@@ -153,3 +155,6 @@ services:
         $lang: '%env(resolve:LANG)%'
         $allow_email: '%env(resolve:ALLOW_EMAIL)%'
         $env: '%kernel.environment%'
+
+    App\Service\Url:
+      arguments:

--- a/api/src/Service/Mailer.php
+++ b/api/src/Service/Mailer.php
@@ -6,6 +6,7 @@ use App\Entity\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class Mailer
 {
@@ -16,6 +17,7 @@ class Mailer
     private $logger;
     private $symfonyMailer;
     private $twig;
+    private Url $url;
 
     public function __construct(
         \Twig\Environment $twig,
@@ -25,6 +27,7 @@ class Mailer
         string $env,
         LoggerInterface $logger,
         MailerInterface $symfonyMailer,
+        Url $url,
     ) {
         $this->allow_email = $allow_email;
         $this->domain = $domain;
@@ -33,6 +36,7 @@ class Mailer
         $this->logger = $logger;
         $this->symfonyMailer = $symfonyMailer;
         $this->twig = $twig;
+        $this->url = $url;
     }
 
     private function sendMail($email)
@@ -74,7 +78,7 @@ class Mailer
                 $this->twig->render(
                     "notification-email.$lang.txt.twig",
                     [
-                        'domain' => $this->domain,
+                        'base_url' => $this->url->getBaseUrl(),
                         'notifications' => $notifications,
                         'user' => $user,
                         'unsubscribe_token' => $unsubscribe_token,
@@ -110,8 +114,7 @@ class Mailer
                     "password-reset-mail.$lang.txt.twig",
                     [
                         'name' => ucfirst($user->getName()),
-                        'url' => 'https://'
-                        .$this->domain
+                        'url' => $this->url->getBaseUrl()
                         .'/password-reset'
                         .'?mail='.urlencode($user->getLogin())
                         .'&key='.$token,

--- a/api/src/Service/Mailer.php
+++ b/api/src/Service/Mailer.php
@@ -6,7 +6,6 @@ use App\Entity\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class Mailer
 {

--- a/api/src/Service/Url.php
+++ b/api/src/Service/Url.php
@@ -56,6 +56,15 @@ class Url
         return $this->linkService->hydrateLink($link);
     }
 
+    public function getBaseUrl(): string
+    {
+        $protocol = $this->params->get('protocol');
+        $domain = $this->params->get('domain');
+        $port = $this->params->get('port');
+
+        return $protocol . '://' . $domain . ($port ? ':' . $port : '');
+    }
+
     // taken from https://github.com/guzzle/psr7/blob/089edd38f5b8abba6cb01567c2a8aaa47cec4c72/src/Uri.php#L166
     public static function composeComponents(?string $scheme, ?string $authority, string $path, ?string $query, ?string $fragment): string
     {

--- a/api/templates/notification-email.en.txt.twig
+++ b/api/templates/notification-email.en.txt.twig
@@ -4,12 +4,12 @@ There is something new in Zusam!
 You can see these new messages by going to the following links:
 {% for notification in notifications %}
 {% if notification.type == 'new_message' %}
-- https://{{ domain }}/messages/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.target }}
 {% endif %}
 {% if notification.type == 'new_comment' %}
-- https://{{ domain }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
 {% endif %}
 {% endfor %}
 
 If you do not want to receive this email anymore, you can deactivate it in your settings or click on the following link:
-https://{{ domain }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}
+{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}

--- a/api/templates/notification-email.es.txt.twig
+++ b/api/templates/notification-email.es.txt.twig
@@ -4,12 +4,12 @@ Hola {{ name }},
 Puedes ver estos nuevos mensajes en los siguientes enlaces:
 {% for notification in notifications %}
 {% if notification.type == 'new_message' %}
-- https://{{ domain }}/messages/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.target }}
 {% endif %}
 {% if notification.type == 'new_comment' %}
-- https://{{ domain }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
 {% endif %}
 {% endfor %}
 
 Si ya no desea recibir este correo, puede desactivarlo en su configuración o hacer clic en el siguiente enlace:
-https://{{ domain }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}
+{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}

--- a/api/templates/notification-email.fr.txt.twig
+++ b/api/templates/notification-email.fr.txt.twig
@@ -4,12 +4,12 @@ Il y a du nouveau sur Zusam !
 Vous pouvez voir ces nouveaux messages en vous rendant sur les liens suivants :
 {% for notification in notifications %}
 {% if notification.type == 'new_message' %}
-- https://{{ domain }}/messages/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.target }}
 {% endif %}
 {% if notification.type == 'new_comment' %}
-- https://{{ domain }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
 {% endif %}
 {% endfor %}
 
 Si vous ne voulez plus recevoir ces emails vous pouvez les désactiver dans vos paramètres ou cliquer sur le lien suivant :
-https://{{ domain }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}
+{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}

--- a/api/templates/notification-email.sk.txt.twig
+++ b/api/templates/notification-email.sk.txt.twig
@@ -4,12 +4,12 @@ Na Zusam-e máš nové príspevky!
 Môžeš si ich pozriet na nasledovnom odkazoch:
 {% for notification in notifications %}
 {% if notification.type == 'new_message' %}
-- https://{{ domain }}/messages/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.target }}
 {% endif %}
 {% if notification.type == 'new_comment' %}
-- https://{{ domain }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
 {% endif %}
 {% endfor %}
 
 Ak nechceš dostávať tento email, môžeš to vypnúť v tvojich nastaveniach alebo kliknúť na nasledujúci odkaz:
-https://{{ domain }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}
+{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}


### PR DESCRIPTION
This pull request adds PORT and PROTOCOL environment variables so allow these to be configurable. Previous notifications assumed https and no port.

New base_url method for calculating the base URL from the components.

Updated notification and password reset email templates to use the new function.