### PR TITLE
Add config option to show or hide the invite link for groups

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -11,7 +11,7 @@ ALLOW_PDF_UPLOAD="true"
 ALLOW_AUDIO_UPLOAD="false" # not allowed since backend is not ready
 
 # Can users invite?
-SHOW_GROUP_INVITATION_LINKS="false"
+SHOW_GROUP_INVITATION_LINKS="true"
 
 # Task execution intervals in seconds
 CRON_CONVERT_IMAGES="60" # 1 minute

--- a/api/.env
+++ b/api/.env
@@ -10,6 +10,9 @@ ALLOW_IMAGE_UPLOAD="true"
 ALLOW_PDF_UPLOAD="true"
 ALLOW_AUDIO_UPLOAD="false" # not allowed since backend is not ready
 
+# Can users invite?
+SHOW_GROUP_INVITATION_LINKS="false"
+
 # Task execution intervals in seconds
 CRON_CONVERT_IMAGES="60" # 1 minute
 CRON_CONVERT_VIDEO="3600" # 1 hour

--- a/api/.env
+++ b/api/.env
@@ -29,8 +29,10 @@ APP_ENV="prod"
 APP_SECRET="thisisaplaceholdersecret"
 ###< symfony/framework-bundle ###
 
-# DOMAIN is used to generate urls
+# Base URL information
+PROTOCOL="http"
 DOMAIN="localhost"
+PORT=""
 
 # LANG is the default language of the API
 LANG="en_US"

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -125,6 +125,9 @@ services:
     App\Command\NotificationEmails:
       arguments:
 
+    App\Command\ListInviteLinks:
+      arguments:
+
     App\Command\StorageStatistics:
       arguments:
         $dsn: '%env(resolve:DATABASE_URL)%'

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -11,6 +11,7 @@ parameters:
   allow.upload.video: '%env(resolve:ALLOW_VIDEO_UPLOAD)%'
   allow.upload.pdf: '%env(resolve:ALLOW_PDF_UPLOAD)%'
   allow.upload.audio: '%env(resolve:ALLOW_AUDIO_UPLOAD)%'
+  show.group.invitation.links: '%env(resolve:SHOW_GROUP_INVITATION_LINKS)%'
   idle_hours: '%env(resolve:IDLE_HOURS)%'
   video_conversion_threads: '%env(resolve:VIDEO_CONVERSION_THREADS)%'
   video_format_not_converted: '%env(resolve:VIDEO_FORMAT_NOT_CONVERTED)%'

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -3,7 +3,9 @@
 parameters:
   lang: '%env(resolve:LANG)%'
   version: '%env(resolve:VERSION)%'
+  protocol: '%env(resolve:PROTOCOL)%'
   domain: '%env(resolve:DOMAIN)%'
+  port: '%env(resolve:PORT)%'
   app_env: '%env(resolve:APP_ENV)%'
   allow.upload.image: '%env(resolve:ALLOW_IMAGE_UPLOAD)%'
   allow.upload.video: '%env(resolve:ALLOW_VIDEO_UPLOAD)%'
@@ -153,3 +155,6 @@ services:
         $lang: '%env(resolve:LANG)%'
         $allow_email: '%env(resolve:ALLOW_EMAIL)%'
         $env: '%kernel.environment%'
+
+    App\Service\Url:
+      arguments:

--- a/api/src/Command/ListInviteLinks.php
+++ b/api/src/Command/ListInviteLinks.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Group;
+use App\Service\Url;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListInviteLinks extends Command
+{
+    private $em;
+    private $output;
+    private Url $url;
+
+    public function __construct(
+        EntityManagerInterface $em,
+        Url $url,
+    ) {
+        parent::__construct();
+        $this->em = $em;
+        $this->url = $url;
+    }
+
+    protected function configure()
+    {
+        $this->setName('zusam:invitations:list')
+             ->setDescription('List the invite link for each group')
+             ->addOption('group-id', null, InputOption::VALUE_REQUIRED, "What's the ID of the group to fetch invites for?")
+             ->setHelp('List the invitation links for each of the groups');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->output = $output;
+        if ($input->getOption('group-id')) {
+            $group = $this->em->getRepository(Group::class)->find($input->getOption('group-id'));
+            if ($group) {
+                $this->output->writeln([
+                    $this->url->getBaseUrl() . '/invitation/' . $group->getSecretKey(),
+                ]);
+            } else {
+                $this->output->writeln([
+                    'Group ID not found',
+                ]);
+            }
+            return 0;
+        }
+
+        $groups = $this->em->getRepository(Group::class)->findAll();
+        $table = new Table($output);
+        $table->setHeaders(['Group ID', 'Group Name', 'Invite Link']);
+        foreach ($groups as $group) {
+            $table->addRow([$group->getId(), $group->getName(), $this->url->getBaseUrl() . '/invitation/' . $group->getSecretKey()]);
+        }
+        $table->render();
+
+        return 0;
+    }
+}

--- a/api/src/Command/ResetInviteLink.php
+++ b/api/src/Command/ResetInviteLink.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Group;
+use App\Service\Url;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ResetInviteLink extends Command
+{
+    private $em;
+    private $output;
+    private Url $url;
+
+    public function __construct(
+        EntityManagerInterface $em,
+        Url $url,
+    ) {
+        parent::__construct();
+        $this->em = $em;
+        $this->url = $url;
+    }
+
+    protected function configure()
+    {
+        $this->setName('zusam:invitations:reset')
+             ->setDescription('Resets the invitation key for a group')
+             ->addOption('group-id', null, InputOption::VALUE_REQUIRED, "What's the ID of the group to fetch invites for?")
+             ->setHelp('Resets the invitation key for the selected group and outputs the new invitation link');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->output = $output;
+        if ($input->getOption('group-id')) {
+            $group = $this->em->getRepository(Group::class)->find($input->getOption('group-id'));
+            if ($group) {
+                $group->resetSecretKey();
+                $this->em->persist($group);
+                $this->em->flush();
+
+                $this->output->writeln([
+                    $this->url->getBaseUrl() . '/invitation/' . $group->getSecretKey(),
+                ]);
+            } else {
+                $this->output->writeln([
+                    'Group ID not found',
+                ]);
+            }
+            return 0;
+        }
+
+        return 0;
+    }
+}

--- a/api/src/Controller/Group/Get.php
+++ b/api/src/Controller/Group/Get.php
@@ -59,8 +59,11 @@ class Get extends ApiController
         $data = $this->cache->get($cacheKey, function (ItemInterface $item) use ($group) {
             $item->expiresAfter(3600 * 24 * 7);
             $item->tag('group_'.$group->getId());
-
-            return $this->serialize($group, ['read_group']);
+            $serialization_groups = ['read_group'];
+            if ($this->getParameter('show.group.invitation.links') == 'true') {
+                $serialization_groups[] = 'read_secret_key';
+            }
+            return $this->serialize($group, $serialization_groups);
         });
 
         return new Response(

--- a/api/src/Controller/Group/ResetInviteKey.php
+++ b/api/src/Controller/Group/ResetInviteKey.php
@@ -43,8 +43,10 @@ class ResetInviteKey extends ApiController
         string $id,
         #[CurrentUser] User $currentUser
     ): Response {
-        $this->denyAccessUnlessGranted('ROLE_USER');
-
+        $this->denyAccessUnlessGranted(null);
+        if ($this->getParameter('show.group.invitation.links') != 'true') {
+            return new JsonResponse(['error' => 'Invitation link reset is restricted'], JsonResponse::HTTP_FORBIDDEN);
+        }
         $group = $this->em->getRepository(Group::class)->findOneById($id);
         if (empty($group)) {
             return new JsonResponse(['error' => 'Not Found'], JsonResponse::HTTP_NOT_FOUND);

--- a/api/src/Controller/Group/ResetInviteKey.php
+++ b/api/src/Controller/Group/ResetInviteKey.php
@@ -43,7 +43,6 @@ class ResetInviteKey extends ApiController
         string $id,
         #[CurrentUser] User $currentUser
     ): Response {
-        $this->denyAccessUnlessGranted(null);
         if ($this->getParameter('show.group.invitation.links') != 'true') {
             return new JsonResponse(['error' => 'Invitation link reset is restricted'], JsonResponse::HTTP_FORBIDDEN);
         }

--- a/api/src/Controller/Group/ResetInviteKey.php
+++ b/api/src/Controller/Group/ResetInviteKey.php
@@ -43,6 +43,8 @@ class ResetInviteKey extends ApiController
         string $id,
         #[CurrentUser] User $currentUser
     ): Response {
+        $this->denyAccessUnlessGranted('ROLE_USER');
+
         if ($this->getParameter('show.group.invitation.links') != 'true') {
             return new JsonResponse(['error' => 'Invitation link reset is restricted'], JsonResponse::HTTP_FORBIDDEN);
         }

--- a/api/src/Controller/Info.php
+++ b/api/src/Controller/Info.php
@@ -45,6 +45,9 @@ class Info extends ApiController
           ],
           'default_lang' => $this->getParameter('lang'),
           'allow_email' => 'true' == $this->getParameter('allow.email'),
+          'show' => [
+            'group_invitation_links' => 'true' == $this->getParameter('show.group.invitation.links'),
+          ]
         ], JsonResponse::HTTP_OK);
     }
 }

--- a/api/src/Entity/Group.php
+++ b/api/src/Entity/Group.php
@@ -33,7 +33,7 @@ class Group extends ApiEntity
     /**
      * @ORM\Column(type="string", unique=true)
      *
-     * @Groups({"read_group"})
+     * @Groups({"read_secret_key"})
      *
      * @Assert\NotBlank()
      *

--- a/api/src/Service/Mailer.php
+++ b/api/src/Service/Mailer.php
@@ -6,6 +6,7 @@ use App\Entity\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class Mailer
 {
@@ -16,6 +17,7 @@ class Mailer
     private $logger;
     private $symfonyMailer;
     private $twig;
+    private Url $url;
 
     public function __construct(
         \Twig\Environment $twig,
@@ -25,6 +27,7 @@ class Mailer
         string $env,
         LoggerInterface $logger,
         MailerInterface $symfonyMailer,
+        Url $url,
     ) {
         $this->allow_email = $allow_email;
         $this->domain = $domain;
@@ -33,6 +36,7 @@ class Mailer
         $this->logger = $logger;
         $this->symfonyMailer = $symfonyMailer;
         $this->twig = $twig;
+        $this->url = $url;
     }
 
     private function sendMail($email)
@@ -74,7 +78,7 @@ class Mailer
                 $this->twig->render(
                     "notification-email.$lang.txt.twig",
                     [
-                        'domain' => $this->domain,
+                        'base_url' => $this->url->getBaseUrl(),
                         'notifications' => $notifications,
                         'user' => $user,
                         'unsubscribe_token' => $unsubscribe_token,
@@ -110,8 +114,7 @@ class Mailer
                     "password-reset-mail.$lang.txt.twig",
                     [
                         'name' => ucfirst($user->getName()),
-                        'url' => 'https://'
-                        .$this->domain
+                        'url' => $this->url->getBaseUrl()
                         .'/password-reset'
                         .'?mail='.urlencode($user->getLogin())
                         .'&key='.$token,

--- a/api/src/Service/Mailer.php
+++ b/api/src/Service/Mailer.php
@@ -6,7 +6,6 @@ use App\Entity\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class Mailer
 {

--- a/api/src/Service/Url.php
+++ b/api/src/Service/Url.php
@@ -56,6 +56,15 @@ class Url
         return $this->linkService->hydrateLink($link);
     }
 
+    public function getBaseUrl(): string
+    {
+        $protocol = $this->params->get('protocol');
+        $domain = $this->params->get('domain');
+        $port = $this->params->get('port');
+
+        return $protocol . '://' . $domain . ($port ? ':' . $port : '');
+    }
+
     // taken from https://github.com/guzzle/psr7/blob/089edd38f5b8abba6cb01567c2a8aaa47cec4c72/src/Uri.php#L166
     public static function composeComponents(?string $scheme, ?string $authority, string $path, ?string $query, ?string $fragment): string
     {

--- a/api/templates/notification-email.en.txt.twig
+++ b/api/templates/notification-email.en.txt.twig
@@ -4,12 +4,12 @@ There is something new in Zusam!
 You can see these new messages by going to the following links:
 {% for notification in notifications %}
 {% if notification.type == 'new_message' %}
-- https://{{ domain }}/messages/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.target }}
 {% endif %}
 {% if notification.type == 'new_comment' %}
-- https://{{ domain }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
 {% endif %}
 {% endfor %}
 
 If you do not want to receive this email anymore, you can deactivate it in your settings or click on the following link:
-https://{{ domain }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}
+{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}

--- a/api/templates/notification-email.es.txt.twig
+++ b/api/templates/notification-email.es.txt.twig
@@ -4,12 +4,12 @@ Hola {{ name }},
 Puedes ver estos nuevos mensajes en los siguientes enlaces:
 {% for notification in notifications %}
 {% if notification.type == 'new_message' %}
-- https://{{ domain }}/messages/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.target }}
 {% endif %}
 {% if notification.type == 'new_comment' %}
-- https://{{ domain }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
 {% endif %}
 {% endfor %}
 
 Si ya no desea recibir este correo, puede desactivarlo en su configuración o hacer clic en el siguiente enlace:
-https://{{ domain }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}
+{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}

--- a/api/templates/notification-email.fr.txt.twig
+++ b/api/templates/notification-email.fr.txt.twig
@@ -4,12 +4,12 @@ Il y a du nouveau sur Zusam !
 Vous pouvez voir ces nouveaux messages en vous rendant sur les liens suivants :
 {% for notification in notifications %}
 {% if notification.type == 'new_message' %}
-- https://{{ domain }}/messages/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.target }}
 {% endif %}
 {% if notification.type == 'new_comment' %}
-- https://{{ domain }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
 {% endif %}
 {% endfor %}
 
 Si vous ne voulez plus recevoir ces emails vous pouvez les désactiver dans vos paramètres ou cliquer sur le lien suivant :
-https://{{ domain }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}
+{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}

--- a/api/templates/notification-email.sk.txt.twig
+++ b/api/templates/notification-email.sk.txt.twig
@@ -4,12 +4,12 @@ Na Zusam-e máš nové príspevky!
 Môžeš si ich pozriet na nasledovnom odkazoch:
 {% for notification in notifications %}
 {% if notification.type == 'new_message' %}
-- https://{{ domain }}/messages/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.target }}
 {% endif %}
 {% if notification.type == 'new_comment' %}
-- https://{{ domain }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
+- {{ base_url }}/messages/{{ notification.fromMessage.id }}/{{ notification.target }}
 {% endif %}
 {% endfor %}
 
 Ak nechceš dostávať tento email, môžeš to vypnúť v tvojich nastaveniach alebo kliknúť na nasledujúci odkaz:
-https://{{ domain }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}
+{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}

--- a/app/src/settings/group-settings.component.js
+++ b/app/src/settings/group-settings.component.js
@@ -1,5 +1,5 @@
 import { h } from "preact";
-import { alert, http, util, router } from "/src/core";
+import { alert, http, util, router, api } from "/src/core";
 import { useStoreon } from "storeon/preact";
 import { useEffect, useState } from "preact/hooks";
 import { useTranslation } from "react-i18next";
@@ -108,28 +108,30 @@ export default function GroupSettings() {
                       {t("save_changes")}
                     </button>
                   </form>
-                  <form class="mb-1 border-bottom pb-1">
-                    <div class="form-group">
-                      <label for="inviteKey">
-                        {t("invitation_link")}:{" "}
-                      </label>
-                      <input
-                        type="text"
-                        name="inviteKey"
-                        value={
-                          `${window.location.protocol}//${window.location.host}/invitation/${secretKey}`
-                        }
-                        class="form-control font-size-80"
-                        readonly="readonly"
-                      />
-                    </div>
-                    <button
-                      class="btn btn-outline-secondary"
-                      onClick={resetSecretKey}
-                    >
-                      {t("reset_invitation_link")}
-                    </button>
-                  </form>
+                  {api?.info?.show?.group_invitation_links && (
+                    <form class="mb-1 border-bottom pb-1">
+                      <div class="form-group">
+                        <label for="inviteKey">
+                          {t("invitation_link")}:{" "}
+                        </label>
+                        <input
+                          type="text"
+                          name="inviteKey"
+                          value={
+                            `${window.location.protocol}//${window.location.host}/invitation/${secretKey}`
+                          }
+                          class="form-control font-size-80"
+                          readonly="readonly"
+                        />
+                      </div>
+                      <button
+                        class="btn btn-outline-secondary"
+                        onClick={resetSecretKey}
+                      >
+                        {t("reset_invitation_link")}
+                      </button>
+                    </form>
+                  )}
                   <form>
                     <button
                       onClick={e => leaveGroup(e)}


### PR DESCRIPTION
Added option SHOW_GROUP_INVITATION_LINKS to show or hide invite links for groups.

When set to false, invite link will not show on group settings pages, and reset API will not work, however, existing link will still work.

Also added CLI command to list invite links for groups, and a command to reset the invite link.

This is covers part of #50 

This PR relies on #73 