### PR TITLE
Retrieve default language from API

### DIFF
--- a/app/src/core/lang.js
+++ b/app/src/core/lang.js
@@ -1,6 +1,7 @@
 import me from "./me.js";
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
+import api from "/src/core/api.js";
 
 import cs_CZ from "/src/lang/cs_CZ.json";
 import de_DE from "/src/lang/de_DE.json";
@@ -37,8 +38,7 @@ const lang = {
     zh_Hans: "中文",
   }, // possible dicts names to load
   getDefaultLang: () =>
-    (document.querySelector("meta[name='zusam:default-lang']") || {}).content ||
-    "en_US",
+    (api?.info?.default_lang || "en_US"),
   getCurrentLang: () => me.lang || lang.getDefaultLang(),
 };
 

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -3,7 +3,6 @@
     <head>
         <!-- WEBAPP CONFIGURATION -->
         <base href="/">
-        <meta name="zusam:default-lang" content="en">
         <meta name="zusam:version" content="@VERSION@">
         <!-- -->
 

--- a/container/run.sh
+++ b/container/run.sh
@@ -23,11 +23,6 @@ if [ -f /zusam/config ]; then
     /zusam/config
 fi
 
-if [ -f /zusam/public/index.html ]; then
-  sed -i -e "s|content=\"en\"|content=\"${LANG}\"|g" \
-    /zusam/public/index.html
-fi
-
 if ! [ -f /zusam/data/config ]; then
   cp /zusam/config /zusam/data/config
 fi


### PR DESCRIPTION
Changed how default language is received to use API instead of hard coded into page.

I believe the only outstanding question from our conversation is around how to handle the LANG environment variable not being provided by docker, and the potential to overwrite the .env option.

I thought I'd create this pull request with what I have and then we can tidy up this last outstanding thing (or leave for now if we don't have a good solution).

This is related to #76 but that issue was possibly related to the docker environment variables as I can't reproduce it outside of that setup.