### PR TITLE
Fix English

### DIFF
--- a/app/src/core/lang.js
+++ b/app/src/core/lang.js
@@ -22,7 +22,7 @@ const lang = {
   possibleLang: {
     cs_CZ: "čeština",
     de_DE: "Deutsch",
-    en_US: "english",
+    en_US: "English",
     es_ES: "español",
     fr_FR: "français",
     hu_HU: "magyar nyelv",


### PR DESCRIPTION
In most circumstances, English (the name of the language) should be capitalised. I have updated this in the language list.