### PR TITLE
Fix errors when user deleted

### DIFF
--- a/api/src/Controller/Message/Get.php
+++ b/api/src/Controller/Message/Get.php
@@ -49,7 +49,7 @@ class Get extends ApiController
         $this->denyAccessUnlessGranted(new Expression('user in object.getUsersAsArray()'), $message->getGroup());
         $message_norm = $this->normalize($message, ['read_message']);
         $message_norm['preview'] = $this->normalize($message->getPreview(), ['read_message']);
-        
+
         try {
             $message_norm['author'] = $this->normalize($message->getAuthor(), ['read_message_preview']);
         } catch (EntityNotFoundException $e) {

--- a/api/src/Controller/Message/Get.php
+++ b/api/src/Controller/Message/Get.php
@@ -5,6 +5,7 @@ namespace App\Controller\Message;
 use App\Controller\ApiController;
 use App\Entity\Message;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityNotFoundException;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Security;
 use OpenApi\Annotations as OA;
@@ -48,7 +49,12 @@ class Get extends ApiController
         $this->denyAccessUnlessGranted(new Expression('user in object.getUsersAsArray()'), $message->getGroup());
         $message_norm = $this->normalize($message, ['read_message']);
         $message_norm['preview'] = $this->normalize($message->getPreview(), ['read_message']);
-        $message_norm['author'] = $this->normalize($message->getAuthor(), ['read_message_preview']);
+        
+        try {
+            $message_norm['author'] = $this->normalize($message->getAuthor(), ['read_message_preview']);
+        } catch (EntityNotFoundException $e) {
+            $message_norm['author'] = null;
+        }
 
         $lineage = [];
         $parent = $message->getParent();

--- a/api/src/Controller/Notification/Get.php
+++ b/api/src/Controller/Notification/Get.php
@@ -6,6 +6,7 @@ use App\Controller\ApiController;
 use App\Entity\Notification;
 use App\Service\Notification as NotificationService;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityNotFoundException;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Security;
 use OpenApi\Annotations as OA;
@@ -65,8 +66,11 @@ class Get extends ApiController
         if (Notification::GLOBAL_NOTIFICATION != $notification_data_output['type']
           && empty($notification->getMiniature())
         ) {
-            $notification_data_output['miniature'] = $this->normalize($notification->getFromUser()->getAvatar(), ['read_notification']);
-        }
+            try {
+                $notification_data_output['miniature'] = $this->normalize($notification->getFromUser()->getAvatar(), ['read_notification']);
+            } catch (EntityNotFoundException $e) {
+                $notification_data_output['miniature'] = null;
+            }        }
 
         return new JsonResponse($notification_data_output, Response::HTTP_OK);
     }

--- a/api/src/Controller/Notification/Get.php
+++ b/api/src/Controller/Notification/Get.php
@@ -70,7 +70,8 @@ class Get extends ApiController
                 $notification_data_output['miniature'] = $this->normalize($notification->getFromUser()->getAvatar(), ['read_notification']);
             } catch (EntityNotFoundException $e) {
                 $notification_data_output['miniature'] = null;
-            }        }
+            }
+        }
 
         return new JsonResponse($notification_data_output, Response::HTTP_OK);
     }

--- a/api/src/Service/Notification.php
+++ b/api/src/Service/Notification.php
@@ -73,11 +73,12 @@ class Notification
                 return '';
             }
             $author = $message->getAuthor();
+            $name = $author->getName();
         } catch (\Exception $e) {
             return '';
         }
 
-        return $author->getName();
+        return $name;
     }
 
     public function create($type, $target, $owner, $fromUser = null, $fromGroup = null, $fromMessage = null)


### PR DESCRIPTION
When a user deletes their account, if there are notifications (or another reason to load user details) it causes an internal server error. This is not visible to the user, only in the browser console.

The changes in these commits prevent the server error by handling the scenario.

The user fetch also returns 404 which seems right, but it is logged to the console as an error. I would expect that an expected and handled error shouldn't be logged to the console.

The http.get doesn't throw an error so I can't catch it, perhaps [http.js](https://github.com/zusam/zusam/blob/next/app/src/core/http.js) needs an update? I can do the implementation but I'm not sure what the correct structure looks like.