### PR TITLE
Update container

### DIFF
--- a/container/dockerfile/base.docker
+++ b/container/dockerfile/base.docker
@@ -1,7 +1,7 @@
 // The lastest version number can be found at:
 // https://hub.docker.com/_/alpine
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 RUN apk add --no-cache -U tini s6
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/container/dockerfile/packages.docker
+++ b/container/dockerfile/packages.docker
@@ -1,5 +1,9 @@
+// Alpine packages search website:
+// https://pkgs.alpinelinux.org/packages
+
 RUN set -xe && apk add --no-cache \\
     ffmpeg \\
+    ghostscript \\
     imagemagick \\
     nginx \\
     openssl \\

--- a/container/dockerfile/php-packages.docker
+++ b/container/dockerfile/php-packages.docker
@@ -26,5 +26,5 @@ RUN set -xe && apk add --no-cache \\
     php84-tokenizer \\
     php84-xml \\
     php84-xmlwriter \\
-    && ln -sf /usr/bin/php83 /usr/bin/php
+    && ln -sf /usr/bin/php84 /usr/bin/php
 

--- a/container/dockerfile/php-packages.docker
+++ b/container/dockerfile/php-packages.docker
@@ -1,30 +1,30 @@
 // The correct PHP version can be found at
-// https://pkgs.alpinelinux.org/packages?name=php%3F%3F&branch=v3.20&repo=&arch=x86_64&origin=yes
+// https://pkgs.alpinelinux.org/packages?name=php%3F%3F&branch=v3.21&repo=&arch=x86_64&origin=yes
 // (Switch the branch to the version specified in base.docker)
 
 RUN set -xe && apk add --no-cache \\
-    php83 \\
-    php83-common \\
-    php83-ctype \\
-    php83-curl \\
-    php83-dom \\
-    php83-fileinfo \\
-    php83-fpm \\
-    php83-iconv \\
-    php83-intl \\
-    php83-json \\
-    php83-mbstring \\
-    php83-opcache \\
-    php83-openssl \\
-    php83-pdo_sqlite \\
-    php83-pecl-apcu \\
-    php83-pecl-imagick \\
-    php83-phar \\
-    php83-posix \\
-    php83-session \\
-    php83-simplexml \\
-    php83-tokenizer \\
-    php83-xml \\
-    php83-xmlwriter \\
+    php84 \\
+    php84-common \\
+    php84-ctype \\
+    php84-curl \\
+    php84-dom \\
+    php84-fileinfo \\
+    php84-fpm \\
+    php84-iconv \\
+    php84-intl \\
+    php84-json \\
+    php84-mbstring \\
+    php84-opcache \\
+    php84-openssl \\
+    php84-pdo_sqlite \\
+    php84-pecl-apcu \\
+    php84-pecl-imagick \\
+    php84-phar \\
+    php84-posix \\
+    php84-session \\
+    php84-simplexml \\
+    php84-tokenizer \\
+    php84-xml \\
+    php84-xmlwriter \\
     && ln -sf /usr/bin/php83 /usr/bin/php
 

--- a/container/dockerfile/setup.docker
+++ b/container/dockerfile/setup.docker
@@ -3,7 +3,7 @@ RUN set -xe \\
     && adduser -D -G zusam -u $UID zusam \\
     && mkdir -p /run/nginx /zusam/data /var/tmp/nginx /var/lib/nginx \\
     && apk add --no-cache --virtual .build-deps tar ca-certificates wget unzip \\
-    && COMPOSER_ALLOW_SUPERUSER=1 php83 /zusam/api/bin/composer install -d /zusam/api --no-dev --prefer-dist \\
+    && COMPOSER_ALLOW_SUPERUSER=1 php /zusam/api/bin/composer install -d /zusam/api --no-dev --prefer-dist \\
     && rm -rf /zusam/data/data.db \\
     && apk del .build-deps \\
     && chmod -R 755 /usr/local/bin /etc/s6.d /var/lib/nginx /zusam/public /var/tmp/nginx

--- a/container/dockerfile/setup.docker
+++ b/container/dockerfile/setup.docker
@@ -3,7 +3,7 @@ RUN set -xe \\
     && adduser -D -G zusam -u $UID zusam \\
     && mkdir -p /run/nginx /zusam/data /var/tmp/nginx /var/lib/nginx \\
     && apk add --no-cache --virtual .build-deps tar ca-certificates wget unzip \\
-    && COMPOSER_ALLOW_SUPERUSER=1 php /zusam/api/bin/composer install -d /zusam/api --no-dev --prefer-dist \\
+    && COMPOSER_ALLOW_SUPERUSER=1 /usr/bin/php /zusam/api/bin/composer install -d /zusam/api --no-dev --prefer-dist \\
     && rm -rf /zusam/data/data.db \\
     && apk del .build-deps \\
     && chmod -R 755 /usr/local/bin /etc/s6.d /var/lib/nginx /zusam/public /var/tmp/nginx


### PR DESCRIPTION
This PR updates alpine from `3.20` to `3.21`, update PHP packages from version `8.3` to `8.4` and add the `ghostscript` package, necessary for pdf uploads.