### PR TITLE
Html email templates

### DIFF
--- a/api/src/Command/Cron.php
+++ b/api/src/Command/Cron.php
@@ -171,8 +171,13 @@ class Cron extends Command
         foreach ($this->tasks as $task) {
 
             // If we are only doing "always" tasks, skip others
-            if (!isset($task['type'])
-                || $onlyRunAlwaysTasks && 'always' !== $task['type']) {
+            if (
+                !isset($task['type'])
+                || (
+                    $onlyRunAlwaysTasks
+                    && 'always' !== $task['type']
+                )
+            ) {
                 continue;
             }
 

--- a/api/src/Command/Cron.php
+++ b/api/src/Command/Cron.php
@@ -50,7 +50,7 @@ class Cron extends Command
             [
                 'name' => 'zusam:notification:emails',
                 'period' => intval($this->params->get('cron.notification.emails.throttling')),
-                'type' => 'light',
+                'type' => 'always',
                 'options' => [
                     '--log-send' => true,
                 ],
@@ -140,31 +140,43 @@ class Cron extends Command
         $last_task_timestamp = $this->system->get('last_task_timestamp');
         $last_task_name = $this->system->get('last_task_name');
 
-        // if a task is running and it's not older than MAX_TASK_LOCK_DURATION, do nothing
+        // if a task is running and it's not older than MAX_TASK_LOCK_DURATION, only run our "always" tasks
+        $onlyRunAlwaysTasks = false;
         if ($task_running && isset($last_task_timestamp) && $last_task_timestamp > time() - intval($this->params->get('max_task_lock_duration'))) {
             $this->logger->notice($last_task_name.' is already running since '.(time() - $last_task_timestamp).'s');
 
-            return false;
+            $onlyRunAlwaysTasks = true;
         }
 
-        // if a task is running but it's old, it's probably a lockup.
-        // continue but log it
-        if (isset($last_task_timestamp) && $last_task_timestamp < time() - intval($this->params->get('max_task_lock_duration'))) {
-            $this->logger->notice('Removing old task lock');
-        }
+        // Don't count the always-only task run as the last task when checking for duplicates
+        if (!$onlyRunAlwaysTasks) {
+            // if a task is running but it's old, it's probably a lockup.
+            // continue but log it
+            if (!$onlyRunAlwaysTasks && isset($last_task_timestamp) && $last_task_timestamp < time() - intval($this->params->get('max_task_lock_duration'))) {
+                $this->logger->notice('Removing old task lock');
+            }
 
-        $this->system->set('task_running', true);
+            $this->system->set('task_running', true);
 
-        // get idle hours
-        if (null !== $this->params->get('idle_hours')) {
-            $idle_hours = explode('-', $this->params->get('idle_hours'));
-            $idle_hours[0] = intval($idle_hours[0]);
-            $idle_hours[1] = intval($idle_hours[1]);
-        } else {
-            $idle_hours = [0, 24];
+            // get idle hours
+            if (null !== $this->params->get('idle_hours')) {
+                $idle_hours = explode('-', $this->params->get('idle_hours'));
+                $idle_hours[0] = intval($idle_hours[0]);
+                $idle_hours[1] = intval($idle_hours[1]);
+            } else {
+                $idle_hours = [0, 24];
+            }
         }
 
         foreach ($this->tasks as $task) {
+
+            // If we are only doing "always" tasks, skip others
+            if ($onlyRunAlwaysTasks
+                && isset($task['type'])
+                && 'always' !== $task['type']) {
+                continue;
+            }
+
             // if it's a heavy task and we're not in the idle hours, don't do it
             if (
                 isset($task['type'])

--- a/api/src/Command/Cron.php
+++ b/api/src/Command/Cron.php
@@ -178,8 +178,7 @@ class Cron extends Command
 
             // if it's a heavy task and we're not in the idle hours, don't do it
             if (
-                isset($task['type'])
-                && 'heavy' == $task['type']
+                'heavy' == $task['type']
                 && (
                     (new \DateTime())->format('H') < $idle_hours[0]
                     || (new \DateTime())->format('H') > $idle_hours[1]

--- a/api/src/Service/Mailer.php
+++ b/api/src/Service/Mailer.php
@@ -75,16 +75,24 @@ class Mailer
             ->to($user->getLogin())
             ->text(
                 $this->twig->render(
-                    $this->getTemplatePath("notification-email", $lang),
+                    $this->getTemplatePath("notification-email", $lang, 'txt'),
                     [
                         'base_url' => $this->url->getBaseUrl(),
                         'notifications' => $notifications,
                         'user' => $user,
                         'unsubscribe_token' => $unsubscribe_token,
                     ]
-                ),
-                'text/plain'
+                )
             )
+            ->html($this->twig->render(
+                $this->getTemplatePath("notification-email", $lang, 'html'),
+                [
+                    'base_url' => $this->url->getBaseUrl(),
+                    'notifications' => $notifications,
+                    'user' => $user,
+                    'unsubscribe_token' => $unsubscribe_token,
+                ]
+            ))
         ;
 
         return $this->sendMail($email);
@@ -110,7 +118,7 @@ class Mailer
             ->to($user->getLogin())
             ->text(
                 $this->twig->render(
-                    $this->getTemplatePath("password-reset-mail", $lang),
+                    $this->getTemplatePath("password-reset-mail", $lang, 'txt'),
                     [
                         'name' => ucfirst($user->getName()),
                         'url' => $this->url->getBaseUrl()
@@ -118,18 +126,29 @@ class Mailer
                         .'?mail='.urlencode($user->getLogin())
                         .'&key='.$token,
                     ]
-                ),
-                'text/plain'
+                )
+            )
+            ->html(
+                $this->twig->render(
+                    $this->getTemplatePath("password-reset-mail", $lang, 'html'),
+                    [
+                        'name' => ucfirst($user->getName()),
+                        'url' => $this->url->getBaseUrl()
+                            .'/password-reset'
+                            .'?mail='.urlencode($user->getLogin())
+                            .'&key='.$token,
+                    ]
+                )
             )
         ;
 
         return $this->sendMail($email);
     }
 
-    private function getTemplatePath(string $template, string $lang): string
+    private function getTemplatePath(string $template, string $lang, string $type): string
     {
-        $templatePath = "$template.$lang.txt.twig";
-        $defaultTemplatePath = "$template.en_US.txt.twig";
+        $templatePath = "$template.$lang.$type.twig";
+        $defaultTemplatePath = "$template.en_US.$type.twig";
         if ($this->twig->getLoader()->exists($templatePath)) {
             return $templatePath;
         }

--- a/api/templates/notification-email.en_US.html.twig
+++ b/api/templates/notification-email.en_US.html.twig
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>New Content on Zusam</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            background-color: #fff;
+            color: #333;
+            max-width: 600px;
+            margin: 50px auto;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .post {
+            border-bottom: 1px solid #ddd;
+            padding: 15px 0;
+        }
+        .post:last-child {
+            border-bottom: none;
+        }
+        .post-title {
+            font-size: 18px;
+            font-weight: bold;
+            color: #f7a71b;
+            text-decoration: none;
+        }
+        .button {
+            background-color: #f7a71b;
+            color: #fff;
+            padding: 10px 20px;
+            text-decoration: none;
+            border-radius: 4px;
+            display: inline-block;
+            font-weight: bold;
+            font-size: 16px;
+            margin-top: 20px;
+            text-align: center;
+        }
+        .unsubscribe {
+            font-size: 0.9em;
+            color: #555;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>New Content on Zusam</h1>
+        <p>Hello {{ user.name }},</p>
+        <p>Check out the latest posts:</p>
+
+        {% for notification in notifications %}
+            {% if notification.notification.type == 'new_message' %}
+            <div class="post">
+                <a href="{{ base_url }}/messages/{{ notification.notification.target }}" class="post-title">{{ notification.title }}</a>
+            </div>
+            {% endif %}
+        {% endfor %}
+
+        <p>
+            <a href="{{ base_url }}/feed" class="button">View feed</a>
+        </p>
+        <footer>
+            <p class="unsubscribe">
+                If you no longer wish to receive these emails, you can
+                <a href="{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}">unsubscribe here</a>.
+            </p>
+        </footer>
+    </div>
+</body>
+</html>
+

--- a/api/templates/password-reset-mail.en_US.html.twig
+++ b/api/templates/password-reset-mail.en_US.html.twig
@@ -1,0 +1,48 @@
+{% autoescape false %}
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Zusam Password Reset Request</title>
+        <style>
+            body {
+                font-family: Arial, sans-serif;
+                background-color: #f4f4f4;
+                margin: 0;
+                padding: 0;
+            }
+            .container {
+                background-color: #fff;
+                color: #333;
+                max-width: 600px;
+                margin: 50px auto;
+                padding: 20px;
+                border-radius: 8px;
+                box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            }
+            .button {
+                background-color: #f7a71b;
+                color: #fff;
+                padding: 10px 20px;
+                text-decoration: none;
+                border-radius: 4px;
+                display: inline-block;
+                font-weight: bold;
+                font-size: 16px;
+                transition: background-color 0.3s, border-color 0.3s;
+            }
+        </style>
+    </head>
+    <body>
+    <div class="container">
+        <h1>Password Reset Request</h1>
+        <p>Hello {{ name }},</p>
+        <p>We received a request to reset your password. Click the button below to set up a new password:</p>
+        <p>
+            <a href="{{ url }}" class="button">Reset Password</a>
+        </p>
+        <p>If you did not request a password reset, you can safely ignore this email.</p>
+    </div>
+    </body>
+    </html>
+{% endautoescape %}


### PR DESCRIPTION
Added HTML email templates for notification email and password reset email. It lists the name of the post with a link, and a link to the feed at the bottom. I'm no UI expert but I think it looks ok. E.g.:

![screen shot of email from zusam - list of names of new posts + a view feed button](https://github.com/user-attachments/assets/99590baf-6666-4d68-a91c-5512860c0451)

I believe this resolves #48, although that user is not using English and other templates would need to be created for other languages. These templates are only for English in this pull request. 

Text emails are not affected. If a user has an email client where they have requested text emails, they will be the same as before.
 
This PR also includes an earlier database write to mitigate duplicate emails when the process is running multiple times at the same time. 