### PR TITLE
Refactor invites to use a separate invite key

### DIFF
--- a/api/migrations/Version20250520004944.php
+++ b/api/migrations/Version20250520004944.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250520004944 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TEMPORARY TABLE __temp__group AS SELECT id, created_at, name, last_activity_date, secret_key, data FROM "group"');
+        $this->addSql('DROP TABLE "group"');
+        $this->addSql('CREATE TABLE "group" (id CHAR(36) NOT NULL --(DC2Type:guid)
+        , created_at INTEGER NOT NULL, name VARCHAR(255) NOT NULL, last_activity_date INTEGER DEFAULT NULL, secret_key VARCHAR(255) NOT NULL, data CLOB DEFAULT NULL --(DC2Type:json)
+        , invite_key VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('INSERT INTO "group" (id, created_at, name, last_activity_date, secret_key, data) SELECT id, created_at, name, last_activity_date, secret_key, data FROM __temp__group');
+        $this->addSql('DROP TABLE __temp__group');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_6DC044C57F4741F5 ON "group" (secret_key)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_6DC044C5916567E ON "group" (invite_key)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TEMPORARY TABLE __temp__group AS SELECT id, secret_key, created_at, name, last_activity_date, data FROM "group"');
+        $this->addSql('DROP TABLE "group"');
+        $this->addSql('CREATE TABLE "group" (id CHAR(36) NOT NULL --(DC2Type:guid)
+        , secret_key VARCHAR(255) NOT NULL, created_at INTEGER NOT NULL, name VARCHAR(255) NOT NULL, last_activity_date INTEGER DEFAULT NULL, data CLOB DEFAULT NULL --(DC2Type:json)
+        , PRIMARY KEY(id))');
+        $this->addSql('INSERT INTO "group" (id, secret_key, created_at, name, last_activity_date, data) SELECT id, secret_key, created_at, name, last_activity_date, data FROM __temp__group');
+        $this->addSql('DROP TABLE __temp__group');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_6DC044C57F4741F5 ON "group" (secret_key)');
+    }
+}

--- a/api/migrations/Version20250520092849.php
+++ b/api/migrations/Version20250520092849.php
@@ -27,6 +27,7 @@ final class Version20250520092849 extends AbstractMigration
         , invite_key VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
         $this->addSql('INSERT INTO "group" (id, secret_key, created_at, name, last_activity_date, data) SELECT id, secret_key, created_at, name, last_activity_date, data FROM __temp__group');
         $this->addSql('DROP TABLE __temp__group');
+        $this->addSql('UPDATE "group" SET invite_key = secret_key');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_6DC044C57F4741F5 ON "group" (secret_key)');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_6DC044C5916567E ON "group" (invite_key)');
     }

--- a/api/migrations/Version20250520092849.php
+++ b/api/migrations/Version20250520092849.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20250520004944 extends AbstractMigration
+final class Version20250520092849 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -20,12 +20,12 @@ final class Version20250520004944 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TEMPORARY TABLE __temp__group AS SELECT id, created_at, name, last_activity_date, secret_key, data FROM "group"');
+        $this->addSql('CREATE TEMPORARY TABLE __temp__group AS SELECT id, secret_key, created_at, name, last_activity_date, data FROM "group"');
         $this->addSql('DROP TABLE "group"');
         $this->addSql('CREATE TABLE "group" (id CHAR(36) NOT NULL --(DC2Type:guid)
-        , created_at INTEGER NOT NULL, name VARCHAR(255) NOT NULL, last_activity_date INTEGER DEFAULT NULL, secret_key VARCHAR(255) NOT NULL, data CLOB DEFAULT NULL --(DC2Type:json)
-        , invite_key VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
-        $this->addSql('INSERT INTO "group" (id, created_at, name, last_activity_date, secret_key, data) SELECT id, created_at, name, last_activity_date, secret_key, data FROM __temp__group');
+        , secret_key VARCHAR(255) NOT NULL, created_at INTEGER NOT NULL, name VARCHAR(255) NOT NULL, last_activity_date INTEGER DEFAULT NULL, data CLOB DEFAULT NULL --(DC2Type:json)
+        , invite_key VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('INSERT INTO "group" (id, secret_key, created_at, name, last_activity_date, data) SELECT id, secret_key, created_at, name, last_activity_date, data FROM __temp__group');
         $this->addSql('DROP TABLE __temp__group');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_6DC044C57F4741F5 ON "group" (secret_key)');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_6DC044C5916567E ON "group" (invite_key)');

--- a/api/src/Command/ListInviteLinks.php
+++ b/api/src/Command/ListInviteLinks.php
@@ -41,7 +41,7 @@ class ListInviteLinks extends Command
             $group = $this->em->getRepository(Group::class)->find($input->getOption('group-id'));
             if ($group) {
                 $inviteKey = $group->getInviteKey();
-                if  ($inviteKey) {
+                if ($inviteKey) {
                     $this->output->writeln([
                         $this->url->getBaseUrl() . '/invitation/' . $inviteKey,
                     ]);
@@ -64,7 +64,7 @@ class ListInviteLinks extends Command
         $table->setHeaders(['Group ID', 'Group Name', 'Invite Link']);
         foreach ($groups as $group) {
             $inviteKey = $group->getInviteKey();
-            if   ($inviteKey) {
+            if ($inviteKey) {
                 $table->addRow([$group->getId(), $group->getName(), $this->url->getBaseUrl() . '/invitation/' . $inviteKey]);
             }
         }

--- a/api/src/Command/ListInviteLinks.php
+++ b/api/src/Command/ListInviteLinks.php
@@ -46,9 +46,7 @@ class ListInviteLinks extends Command
                         $this->url->getBaseUrl() . '/invitation/' . $inviteKey,
                     ]);
                 } else {
-                    $this->output->writeln([
-                        'Group has no invite key. Use zusam:invitations:reset to generate a key.',
-                    ]);
+                    throw new \Exception('Group has no invite key');
                 }
 
             } else {

--- a/api/src/Command/ListInviteLinks.php
+++ b/api/src/Command/ListInviteLinks.php
@@ -40,9 +40,17 @@ class ListInviteLinks extends Command
         if ($input->getOption('group-id')) {
             $group = $this->em->getRepository(Group::class)->find($input->getOption('group-id'));
             if ($group) {
-                $this->output->writeln([
-                    $this->url->getBaseUrl() . '/invitation/' . $group->getSecretKey(),
-                ]);
+                $inviteKey = $group->getInviteKey();
+                if  ($inviteKey) {
+                    $this->output->writeln([
+                        $this->url->getBaseUrl() . '/invitation/' . $inviteKey,
+                    ]);
+                } else {
+                    $this->output->writeln([
+                        'Group has no invite key. Use zusam:invitations:reset to generate a key.',
+                    ]);
+                }
+
             } else {
                 $this->output->writeln([
                     'Group ID not found',
@@ -55,7 +63,10 @@ class ListInviteLinks extends Command
         $table = new Table($output);
         $table->setHeaders(['Group ID', 'Group Name', 'Invite Link']);
         foreach ($groups as $group) {
-            $table->addRow([$group->getId(), $group->getName(), $this->url->getBaseUrl() . '/invitation/' . $group->getSecretKey()]);
+            $inviteKey = $group->getInviteKey();
+            if   ($inviteKey) {
+                $table->addRow([$group->getId(), $group->getName(), $this->url->getBaseUrl() . '/invitation/' . $inviteKey]);
+            }
         }
         $table->render();
 

--- a/api/src/Command/ResetInviteLink.php
+++ b/api/src/Command/ResetInviteLink.php
@@ -39,12 +39,12 @@ class ResetInviteLink extends Command
         if ($input->getOption('group-id')) {
             $group = $this->em->getRepository(Group::class)->find($input->getOption('group-id'));
             if ($group) {
-                $group->resetSecretKey();
+                $group->resetInviteKey();
                 $this->em->persist($group);
                 $this->em->flush();
 
                 $this->output->writeln([
-                    $this->url->getBaseUrl() . '/invitation/' . $group->getSecretKey(),
+                    $this->url->getBaseUrl() . '/invitation/' . $group->getInviteKey(),
                 ]);
             } else {
                 $this->output->writeln([

--- a/api/src/Controller/Group/AddInvitedUser.php
+++ b/api/src/Controller/Group/AddInvitedUser.php
@@ -43,7 +43,7 @@ class AddInvitedUser extends ApiController
     {
         $this->denyAccessUnlessGranted('ROLE_USER');
 
-        $group = $this->em->getRepository(Group::class)->findOneBySecretKey($inviteKey);
+        $group = $this->em->getRepository(Group::class)->findOneByInviteKey($inviteKey);
         if (empty($group)) {
             return new JsonResponse(['error' => 'Invalid invite key !'], Response::HTTP_BAD_REQUEST);
         }

--- a/api/src/Controller/Group/Create.php
+++ b/api/src/Controller/Group/Create.php
@@ -71,7 +71,7 @@ class Create extends ApiController
         $group = $this->groupService->create($requestData['name'], $currentUser);
 
         return new Response(
-            $this->serialize($group, ['read_group', 'read_secret_key']),
+            $this->serialize($group, ['read_group']),
             Response::HTTP_OK
         );
     }

--- a/api/src/Controller/Group/Edit.php
+++ b/api/src/Controller/Group/Edit.php
@@ -105,7 +105,7 @@ class Edit extends ApiController
         $this->em->persist($group);
 
         // Clear cache for the group
-        $this->cache->invalidateTags(['group_'.$group()->getId()]);
+        $this->cache->invalidateTags(['group_'.$group->getId()]);
 
         $this->em->flush();
 

--- a/api/src/Controller/Group/Get.php
+++ b/api/src/Controller/Group/Get.php
@@ -61,7 +61,7 @@ class Get extends ApiController
             $item->tag('group_'.$group->getId());
             $serialization_groups = ['read_group'];
             if ($this->getParameter('show.group.invitation.links') == 'true') {
-                $serialization_groups[] = 'read_secret_key';
+                $serialization_groups[] = 'read_invite_key';
             }
             return $this->serialize($group, $serialization_groups);
         });

--- a/api/src/Controller/Group/ResetInviteKey.php
+++ b/api/src/Controller/Group/ResetInviteKey.php
@@ -55,13 +55,13 @@ class ResetInviteKey extends ApiController
 
         $this->denyAccessUnlessGranted(new Expression('user in object.getUsersAsArray()'), $group);
 
-        $group->resetSecretKey();
+        $group->resetInviteKey();
 
         $currentUser->setLastActivityDate(time());
         $this->em->persist($currentUser);
         $this->em->persist($group);
         $this->em->flush();
 
-        return new JsonResponse(['inviteKey' => $group->getSecretKey()], JsonResponse::HTTP_OK);
+        return new JsonResponse(['inviteKey' => $group->getInviteKey()], JsonResponse::HTTP_OK);
     }
 }

--- a/api/src/Controller/Security.php
+++ b/api/src/Controller/Security.php
@@ -108,7 +108,7 @@ class Security extends AbstractController
             }
         }
 
-        $group = $this->em->getRepository(Group::class)->findOneBySecretKey($inviteKey);
+        $group = $this->em->getRepository(Group::class)->findOneByInviteKey($inviteKey);
 
         if (empty($group)) {
             return $this->json(['message' => 'Invalid invite key !'], Response::HTTP_BAD_REQUEST);

--- a/api/src/Entity/Group.php
+++ b/api/src/Entity/Group.php
@@ -42,6 +42,15 @@ class Group extends ApiEntity
     private $secretKey;
 
     /**
+     * @ORM\Column(type="string", unique=true)
+     *
+     * @Groups({"read_invite_key"})
+     *
+     * @OA\Property(type="string")
+     */
+    private $inviteKey;
+
+    /**
      * @ORM\Column(type="integer")
      *
      * @Assert\Type("integer")
@@ -123,6 +132,7 @@ class Group extends ApiEntity
         $this->messages = new ArrayCollection();
         $this->createdAt = time();
         $this->secretKey = Uuid::uuidv4();
+        $this->inviteKey = Uuid::uuidv4();
     }
 
     public function getId(): string
@@ -138,6 +148,16 @@ class Group extends ApiEntity
     public function resetSecretKey(): void
     {
         $this->secretKey = Uuid::uuidv4();
+    }
+
+    public function getInviteKey(): string
+    {
+        return $this->inviteKey;
+    }
+
+    public function resetInviteKey(): void
+    {
+        $this->inviteKey = Uuid::uuidv4();
     }
 
     public function getCreatedAt(): int

--- a/api/src/Entity/Group.php
+++ b/api/src/Entity/Group.php
@@ -33,7 +33,7 @@ class Group extends ApiEntity
     /**
      * @ORM\Column(type="string", unique=true)
      *
-     * @Groups({"read_secret_key"})
+     * @Groups({"read_group"})
      *
      * @Assert\NotBlank()
      *

--- a/api/src/Entity/Group.php
+++ b/api/src/Entity/Group.php
@@ -42,7 +42,7 @@ class Group extends ApiEntity
     private $secretKey;
 
     /**
-     * @ORM\Column(type="string", unique=true)
+     * @ORM\Column(type="string", unique=true, nullable=true)
      *
      * @Groups({"read_invite_key"})
      *

--- a/api/src/Service/Group.php
+++ b/api/src/Service/Group.php
@@ -28,6 +28,7 @@ class Group
         $this->em->persist($group);
 
         $user->setLastActivityDate(time());
+        $this->addUser($group, $user);
         $this->em->persist($user);
 
         $this->em->flush();

--- a/app/src/pages/create-group.component.js
+++ b/app/src/pages/create-group.component.js
@@ -20,7 +20,7 @@ class CreateGroup extends Component {
     }
     group.createdAt = Math.floor(Date.now() / 1000);
     http.post("/api/groups", group).then(res => {
-        window.location = util.toApp(`/groups/${res.id}`);
+      window.location = util.toApp(`/groups/${res.id}`);
     });
   }
 

--- a/app/src/pages/create-group.component.js
+++ b/app/src/pages/create-group.component.js
@@ -20,9 +20,7 @@ class CreateGroup extends Component {
     }
     group.createdAt = Math.floor(Date.now() / 1000);
     http.post("/api/groups", group).then(res => {
-      http.post(`/api/groups/invitation/${  res.secretKey}`, {}).then(res => {
         window.location = util.toApp(`/groups/${res.id}`);
-      });
     });
   }
 

--- a/app/src/settings/group-settings.component.js
+++ b/app/src/settings/group-settings.component.js
@@ -12,6 +12,7 @@ export default function GroupSettings() {
   const { me, dispatch } = useStoreon("me");
   const navigate = useNavigate();
   const [secretKey, setSecretKey] = useState("");
+  const [inviteKey, setInviteKey] = useState("");
   const [users, setUsers] = useState([]);
   const [group, setGroup] = useState({});
   const [alertMessage, setAlertMessage] = useState("");
@@ -21,6 +22,7 @@ export default function GroupSettings() {
       group => {
         setGroup(group);
         setSecretKey(group.secretKey);
+        setInviteKey(group.inviteKey);
         Promise.all(group.users.map(u => http.get(`/api/users/${u.id}`).then(u => u))).then(
           users => setUsers(users)
         );
@@ -29,13 +31,13 @@ export default function GroupSettings() {
     setAlertMessage(t(router.getParam("alert")));
   }, []);
 
-  const resetSecretKey = (event) => {
+  const resetInviteKey = (event) => {
     event.preventDefault();
     http
       .post(`/api/groups/${group.id}/reset-invite-key`, {})
       .then(res => {
         alert.add(t("group_updated"));
-        setSecretKey(res["inviteKey"]);
+        setInviteKey(res["inviteKey"]);
       });
   };
 
@@ -118,7 +120,7 @@ export default function GroupSettings() {
                           type="text"
                           name="inviteKey"
                           value={
-                            `${window.location.protocol}//${window.location.host}/invitation/${secretKey}`
+                            `${window.location.protocol}//${window.location.host}/invitation/${inviteKey}`
                           }
                           class="form-control font-size-80"
                           readonly="readonly"
@@ -126,7 +128,7 @@ export default function GroupSettings() {
                       </div>
                       <button
                         class="btn btn-outline-secondary"
-                        onClick={resetSecretKey}
+                        onClick={resetInviteKey}
                       >
                         {t("reset_invitation_link")}
                       </button>


### PR DESCRIPTION
This pull request splits the invite functions away from using the group secretKey and adds a new inviteKey property instead. We had previously discussed in #72 to call it invitationKey, then I found the codebase already refers to inviteKey a lot (particularly around the invites) so I went with that. But happy to change it to invitationKey if that's preferred. 

This change separates the invite process from other secretKey functions, allowing sharing of the invite key to be disabled without affecting other functions.

This PR also fixes an issue where the group name couldn't be updated.

In addition, I have made a change to how new groups are created to add the user in the backend, preventing a leak of the invite key in the case that showing the invite link to users is disabled. 

Resolves #72, #90 