### PR TITLE
Email enhancements

### DIFF
--- a/api/src/Command/NotificationEmails.php
+++ b/api/src/Command/NotificationEmails.php
@@ -84,7 +84,7 @@ class NotificationEmails extends Command
             $this->em->flush();
 
             $notifications = array_filter($user->getNotifications()->toArray(), function ($n) use ($lastNotificationEmailCheck) {
-                return $n->getCreatedAt() > $lastNotificationEmailCheck;
+                return $n->getCreatedAt() > $lastNotificationEmailCheck && in_array($n->getType(), ['new_message', 'new_comment'], true);
             });
 
             $notificationService = $this->notificationService;

--- a/api/src/Controller/StopNotificationEmails.php
+++ b/api/src/Controller/StopNotificationEmails.php
@@ -18,7 +18,7 @@ class StopNotificationEmails extends AbstractController
         $this->em = $em;
     }
 
-    #[Route('/public/{user_id}/{token}', methods: ['GET'])]
+    #[Route('/stop-notification-emails/{user_id}/{token}', methods: ['GET'])]
     public function login(string $user_id, string $token)
     {
         $user = $this->em->getRepository(User::class)->findOneById($user_id);

--- a/api/src/Controller/User/Edit.php
+++ b/api/src/Controller/User/Edit.php
@@ -183,7 +183,18 @@ class Edit extends ApiController
             }
         }
         if (!empty($requestData['data'])) {
-            $user->setData(array_merge($user->getData(), $requestData['data']));
+            $data =  $requestData['data'];
+
+            // Don't flood user with notifications if they were previously disabled
+            if (
+                !empty($data['notification_emails'])
+                && $data['notification_emails'] !== 'none'
+                && $user->getData()['notification_emails'] === 'none'
+            ) {
+                $user->setLastNotificationEmailCheck(time());
+            }
+
+            $user->setData(array_merge($user->getData(), $data));
         }
         if (!empty($requestData['avatar'])) {
             $file = $this->em->getRepository(File::class)->findOneById($requestData['avatar']);

--- a/api/src/Service/Mailer.php
+++ b/api/src/Service/Mailer.php
@@ -69,31 +69,36 @@ class Mailer
             'sub' => Token::SUB_STOP_EMAIL_NOTIFICATIONS,
         ], $user->getSecretKey());
 
-        $email = (new Email())
-            ->subject('Zusam Notification Email')
-            ->from('noreply@'.$this->domain)
-            ->to($user->getLogin())
-            ->text(
-                $this->twig->render(
-                    $this->getTemplatePath("notification-email", $lang, 'txt'),
-                    [
-                        'base_url' => $this->url->getBaseUrl(),
-                        'notifications' => $notifications,
-                        'user' => $user,
-                        'unsubscribe_token' => $unsubscribe_token,
-                    ]
+        try {
+            $email = (new Email())
+                ->subject('Zusam Notification Email')
+                ->from('noreply@' . $this->domain)
+                ->to($user->getLogin())
+                ->text(
+                    $this->twig->render(
+                        $this->getTemplatePath("notification-email", $lang, 'txt'),
+                            [
+                                'base_url' => $this->url->getBaseUrl(),
+                                'notifications' => $notifications,
+                                'user' => $user,
+                                'unsubscribe_token' => $unsubscribe_token,
+                            ]
+                    )
                 )
-            )
-            ->html($this->twig->render(
-                $this->getTemplatePath("notification-email", $lang, 'html'),
-                [
-                    'base_url' => $this->url->getBaseUrl(),
-                    'notifications' => $notifications,
-                    'user' => $user,
-                    'unsubscribe_token' => $unsubscribe_token,
-                ]
-            ))
-        ;
+                ->html($this->twig->render(
+                    $this->getTemplatePath("notification-email", $lang, 'html'),
+                        [
+                            'base_url' => $this->url->getBaseUrl(),
+                            'notifications' => $notifications,
+                            'user' => $user,
+                            'unsubscribe_token' => $unsubscribe_token,
+                        ]
+                ))
+            ;
+        } catch (\Exception $e) {
+            $this->logger->error('Could not send email to ' . $user->getLogin() . '. Error: ' . $e->getMessage());
+            return false;
+        }
 
         return $this->sendMail($email);
     }

--- a/api/templates/notification-email.en_US.html.twig
+++ b/api/templates/notification-email.en_US.html.twig
@@ -81,8 +81,12 @@
         </p>
         <footer>
             <p class="unsubscribe">
+                To change the frequency of emails,
+                <a href="{{ base_url }}/users/{{ user.id }}/settings">visit your settings page</a>.
+            </p>
+            <p class="unsubscribe">
                 If you no longer wish to receive these emails, you can
-                <a href="{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}">unsubscribe here</a>.
+                <a href="{{ base_url }}/stop-notification-emails/{{ user.id }}/{{ unsubscribe_token }}">unsubscribe</a>.
             </p>
         </footer>
     </div>

--- a/api/templates/notification-email.en_US.html.twig
+++ b/api/templates/notification-email.en_US.html.twig
@@ -21,16 +21,25 @@
         }
         .post {
             border-bottom: 1px solid #ddd;
-            padding: 15px 0;
+            padding: 0 0 15px 0;
         }
         .post:last-child {
             border-bottom: none;
         }
         .post-title {
-            font-size: 18px;
+            font-size: 1.2em;
             font-weight: bold;
             color: #f7a71b;
             text-decoration: none;
+        }
+        li {
+            font-size: 1.2em;
+        }
+        ul {
+            margin: 0;
+        }
+        p {
+            font-size: 1em;
         }
         .button {
             background-color: #f7a71b;
@@ -52,17 +61,20 @@
 </head>
 <body>
     <div class="container">
-        <h1>New Content on Zusam</h1>
+        <h2>New Content on Zusam</h2>
         <p>Hello {{ user.name }},</p>
-        <p>Check out the latest posts:</p>
-
-        {% for notification in notifications %}
-            {% if notification.notification.type == 'new_message' %}
-            <div class="post">
-                <a href="{{ base_url }}/messages/{{ notification.notification.target }}" class="post-title">{{ notification.title }}</a>
-            </div>
-            {% endif %}
-        {% endfor %}
+        <p>Check out the newest content on Zusam:</p>
+        <div class="post">
+            <ul>
+            {% for notification in notifications %}
+                {% if notification.notification.type == 'new_message' %}
+                    <li><strong>{{ notification.notification.fromUser.name }}</strong> created a post <a href="{{ base_url }}/messages/{{ notification.notification.target }}" class="post-title">{{ notification.title }}</a></li>
+                {%  elseif notification.notification.type == 'new_comment' %}
+                    <li><strong>{{ notification.notification.fromUser.name }}</strong> has commented on the post <a href="{{ base_url }}/messages/{{ notification.notification.fromMessage.id }}/{{ notification.notification.target }}" class="post-title">{{ notification.title }}</a></li>
+                {% endif %}
+            {% endfor %}
+            </ul>
+        </div>
 
         <p>
             <a href="{{ base_url }}/feed" class="button">View feed</a>

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -94,7 +94,7 @@ function App() {
       <Route path="/public/:token" element={<Public />} />
       <Route path="/share" element={<Share />} />
       <Route path="/signup" element={<Signup />} />
-      <Route path="/stop-notification-emails" element={<StopNotificationEmails />} />
+      <Route path="/stop-notification-emails/:userId/:token" element={<StopNotificationEmails />} />
       <Route path="/login" element={<Login />} />
       <Route path="/logout" element={<Navigate replace to="/login" />} />
       <Route path="/:type/:id/settings" element={<Settings />} />


### PR DESCRIPTION
This pull request contains the following enhancements:

- Emails now only trigger for notifications of new messages and comments. E.g. new user joining or group renaming no longer trigger an email.
- The HTML formatted email originally only showed new posts (and arrived blank for others). This now includes both new messages and comments.
- The HTML notification email now includes a link to the user's settings page to change the frequency of emails. Previously there was only an unsubscribe button, now it lets them know they can change the frequency.
- The unsubscribe button was broken in 0.5.6, this now works again.
- Currently if an email address is invalid, the process fails and any users not yet iterated over will not get an email. This is now fixed, the error will be caught and logged and then sending will continue for the next user.
- With recent changes to emails, we send any notifications since the last check. We only check for notifications if we meet the conditions based on the user settings. This means if a user has notifications set to "none", they are never checked. If they later change this to receive notifications, the last check was some large time ago and they will get an email with every notification since they last had notifications enabled. This change means when changing from "none" to something else, the last notification check time is set to now to prevent this.