### PR TITLE
Fix group name in notifications

### DIFF
--- a/api/src/Controller/Notification/Get.php
+++ b/api/src/Controller/Notification/Get.php
@@ -50,6 +50,7 @@ class Get extends ApiController
             return new JsonResponse(['error' => 'Not Found'], Response::HTTP_NOT_FOUND);
         }
         $notification_data_output = $this->normalize($notification, ['read_notification']);
+        $notification_data_output["fromGroup"] = $this->normalize($notification->getFromGroup(), ['read_notification']);
 
         if (in_array(
             $notification->getType(),


### PR DESCRIPTION
Group names in notifications was broken in 0.5.4 by what appears to be unintentionally deleting one line too many during refactoring. This PR restores the required line of code so that the name of the group now appears in the notification when relevant.