### PR TITLE
Resolve API test issues + mark migrations as completed on init of fresh database

### DIFF
--- a/api/src/Command/Initialize.php
+++ b/api/src/Command/Initialize.php
@@ -65,6 +65,21 @@ class Initialize extends Command
             '--force' => true,
         ]), $output);
 
+        $syncCommand = $this->getApplication()->find('doctrine:migrations:sync-metadata-storage');
+        $syncCommand->run(new ArrayInput([
+            'command' => 'doctrine:migrations:sync-metadata-storage',
+        ]), $output);
+
+        $versionCommand = $this->getApplication()->find('doctrine:migrations:version');
+        $args = new ArrayInput([
+            'command' => 'doctrine:migrations:version',
+            '--add' => true,
+            '--all' => true,
+        ]);
+        $args->setInteractive(false);
+
+        $versionCommand->run($args, $output);
+
         $user = $this->em->getRepository(User::class)->findOneByLogin($input->getArgument('user'));
         // Only execute the rest of the initialization if the user doesn't exist
         if (empty($user)) {

--- a/api/src/Command/Initialize.php
+++ b/api/src/Command/Initialize.php
@@ -65,12 +65,12 @@ class Initialize extends Command
             '--force' => true,
         ]), $output);
 
-        $syncCommand = $this->getApplication()->find('doctrine:migrations:sync-metadata-storage');
-        $syncCommand->run(new ArrayInput([
+        $doctrineMigrationsSync = $this->getApplication()->find('doctrine:migrations:sync-metadata-storage');
+        $doctrineMigrationsSync->run(new ArrayInput([
             'command' => 'doctrine:migrations:sync-metadata-storage',
         ]), $output);
 
-        $versionCommand = $this->getApplication()->find('doctrine:migrations:version');
+        $doctrineMigrationsVersion = $this->getApplication()->find('doctrine:migrations:version');
         $args = new ArrayInput([
             'command' => 'doctrine:migrations:version',
             '--add' => true,
@@ -78,7 +78,7 @@ class Initialize extends Command
         ]);
         $args->setInteractive(false);
 
-        $versionCommand->run($args, $output);
+        $doctrineMigrationsVersion->run($args, $output);
 
         $user = $this->em->getRepository(User::class)->findOneByLogin($input->getArgument('user'));
         // Only execute the rest of the initialization if the user doesn't exist

--- a/api/src/Controller/File/GetMiniature.php
+++ b/api/src/Controller/File/GetMiniature.php
@@ -69,7 +69,7 @@ class GetMiniature extends ApiController
         if (is_readable($cacheFile)) {
             return new BinaryFileResponse($cacheFile, 200, ['Content-Type' => mime_content_type($cacheFile)]);
         }
-        
+
         return new JsonResponse(['message' => 'Not Found'], JsonResponse::HTTP_NOT_FOUND);
     }
 }

--- a/api/src/Controller/File/GetMiniature.php
+++ b/api/src/Controller/File/GetMiniature.php
@@ -66,6 +66,10 @@ class GetMiniature extends ApiController
             }
         }
 
+        if (is_readable($cacheFile)) {
+            return new BinaryFileResponse($cacheFile, 200, ['Content-Type' => mime_content_type($cacheFile)]);
+        }
+        
         return new JsonResponse(['message' => 'Not Found'], JsonResponse::HTTP_NOT_FOUND);
     }
 }

--- a/api/src/Controller/Message/Search.php
+++ b/api/src/Controller/Message/Search.php
@@ -117,8 +117,7 @@ class Search extends ApiController
             "SELECT m FROM App\Entity\Message m"
             ." WHERE m.group = '".$group->getId()."'"
         );
-        $messages = $query->iterate();
-
+        $messages = $query->toIterable();
         // flatten the search terms before starting the search
         $flattened_search_terms = array_map(function ($e) {
             return StringUtils::remove_accents($e);
@@ -127,8 +126,7 @@ class Search extends ApiController
         $totalItems = 0;
         $results = [];
         $i = 0;
-        foreach ($messages as $row) {
-            $message = $row[0];
+        foreach ($messages as $message) {
             ++$i;
             $data = $message->getData();
             $score = 0;
@@ -203,7 +201,7 @@ class Search extends ApiController
             }
 
             // detach from Doctrine, so that it can be Garbage-Collected immediately
-            $this->em->detach($row[0]);
+            $this->em->detach($message);
         }
 
         usort($results, function ($a, $b) {

--- a/api/src/Entity/ApiEntity.php
+++ b/api/src/Entity/ApiEntity.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping\MappedSuperclass;
+
 #[MappedSuperclass]
 abstract class ApiEntity
 {

--- a/api/src/Entity/Bookmark.php
+++ b/api/src/Entity/Bookmark.php
@@ -82,4 +82,9 @@ class Bookmark extends ApiEntity
     {
         $this->message = $message;
     }
+
+    public function getEntityType(): string
+    {
+        return strtolower((new \ReflectionClass($this))->getShortName());
+    }
 }

--- a/api/src/Entity/Bookmark.php
+++ b/api/src/Entity/Bookmark.php
@@ -16,30 +16,40 @@ class Bookmark extends ApiEntity
     #[ORM\Column(type: 'guid')]
     #[Assert\NotBlank]
     #[Groups(['public'])]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private string $id;
 
     #[ORM\Column(type: 'integer')]
     #[Assert\NotNull]
     #[Assert\Type('integer')]
     #[Groups(['public'])]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private int $createdAt;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'bookmarks')]
     #[Assert\NotNull]
     #[Groups(['public'])]
-    #[OA\Property(type: 'App\Entity\User')]
+    /**
+     * @OA\Property(type="App\Entity\User")
+     */
     private User $user;
 
     #[ORM\ManyToOne(targetEntity: Message::class, inversedBy: 'bookmarks')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     #[Groups(['read_bookmark'])]
-    #[OA\Property(type: 'App\Entity\Message')]
+    /**
+     * @OA\Property(type="App\Entity\Message")
+     */
     private Message $message;
 
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $entityType;
 
     public function __construct()

--- a/api/src/Entity/File.php
+++ b/api/src/Entity/File.php
@@ -24,25 +24,33 @@ class File extends ApiEntity
     #[ORM\Column(type: 'guid')]
     #[Assert\NotBlank]
     #[Groups(['public'])]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private string $id;
 
     #[ORM\Column(type: 'integer')]
     #[Assert\Type('integer')]
     #[Assert\NotNull]
     #[Groups(['read_file'])]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private int $createdAt;
 
     #[ORM\Column(type: 'string')]
     #[Groups(['read_message', 'read_file'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $type;
 
     #[ORM\Column(type: 'string')]
     #[Assert\NotBlank]
     #[Groups(['read_message', 'read_file'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $status;
 
     #[Assert\NotNull]
@@ -50,26 +58,36 @@ class File extends ApiEntity
 
     #[ORM\Column(type: 'string')]
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $contentUrl;
 
     #[ORM\Column(type: 'integer')]
     #[Groups(['read_file'])]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private int $size;
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['read_message', 'read_file'])]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private ?int $fileIndex = null;
 
     #[ORM\Column(type: 'guid', unique: true)]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private string $secretKey;
 
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $entityType;
 
     public function getEntityType(): string

--- a/api/src/Entity/Group.php
+++ b/api/src/Entity/Group.php
@@ -18,57 +18,79 @@ class Group extends ApiEntity
     #[ORM\Column(type: 'guid')]
     #[Groups(['public'])]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private $id;
 
     #[ORM\Column(type: 'string', unique: true)]
     #[Groups(['read_group'])]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private $secretKey;
 
     #[ORM\Column(type: 'string', unique: true, nullable: true)]
     #[Groups(['read_invite_key'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private $inviteKey;
 
     #[ORM\Column(type: 'integer')]
     #[Assert\Type('integer')]
     #[Assert\NotNull]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private $createdAt;
 
     #[ORM\Column(type: 'string')]
     #[Groups(['public'])]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private $name;
 
     #[ORM\ManyToMany(targetEntity: User::class, mappedBy: 'groups')]
     #[Groups(['read_group', 'write_group'])]
-    #[OA\Property(type: 'array', items: new OA\Items(type: User::class))]
+    /**
+     * @OA\Property(type="array", @OA\Items(type="App\Entity\User"))
+     */
     private $users;
 
     #[ORM\OneToMany(targetEntity: Message::class, mappedBy: 'group')]
-    #[OA\Property(type: 'array', items: new OA\Items(type: Message::class))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\Message"))
+    */
     private $messages;
 
     #[ORM\OneToMany(targetEntity: Tag::class, mappedBy: 'group')]
-    #[OA\Property(type: 'array', items: new OA\Items(type: Tag::class))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\Tag"))
+    */
     private $tags;
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['read_group', 'read_me'])]
     #[Assert\Type('integer')]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private $lastActivityDate;
 
     #[ORM\Column(type: 'json', nullable: true)]
-    #[OA\Property(type: 'object')]
+    /**
+     * @OA\Property(type="object")
+     */
     private $data;
 
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private $entityType;
 
     public function getEntityType(): string

--- a/api/src/Entity/Message.php
+++ b/api/src/Entity/Message.php
@@ -18,41 +18,56 @@ class Message extends ApiEntity
     #[ORM\Column(type: 'guid')]
     #[Assert\NotBlank]
     #[Groups(['public'])]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private $id;
 
     #[ORM\Column(type: 'integer')]
     #[Assert\NotNull]
     #[Assert\Type('integer')]
     #[Groups(['read_message'])]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private $createdAt;
 
     #[ORM\Column(type: 'json', nullable: true)]
     #[Assert\NotBlank]
     #[Groups(['read_message', 'read_notification', 'read_message_preview'])]
-    #[OA\Property(type: 'object')]
+    /**
+     * @OA\Property(type="object")
+     */
     private $data;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'messages')]
     #[Groups(['public'])]
-    #[OA\Property(type: User::class)]
+    /**
+     * @OA\Property(type="array", @OA\Items(type="App\Entity\User"))
+     */
     private $author;
 
     #[ORM\ManyToOne(targetEntity: Group::class, inversedBy: 'messages')]
     #[Groups(['read_message'])]
-    #[OA\Property(type: Group::class)]
+    /**
+     * @OA\Property(type="App\Entity\Group")
+     */
     private $group;
 
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id')]
     #[Groups(['read_message'])]
-    #[OA\Property(type: Message::class)]
+    /**
+     * @OA\Property(type="App\Entity\Message")
+     * @OA\Property(type="array", @OA\Items(type="App\Entity\Message"))
+     */
     private $parent;
 
     #[ORM\OneToMany(mappedBy: 'parent', targetEntity: self::class)]
     #[Groups(['read_message'])]
-    #[OA\Property(type: 'array', items: new OA\Items(type: Message::class))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\Message"))
+    */
     private $children;
 
     #[ORM\ManyToMany(targetEntity: File::class)]
@@ -61,55 +76,74 @@ class Message extends ApiEntity
     #[ORM\InverseJoinColumn(name: 'file_id', referencedColumnName: 'id')]
     #[ORM\OrderBy(['fileIndex' => 'ASC'])]
     #[Groups(['read_message'])]
-    #[OA\Property(type: 'array', items: new OA\Items(type: File::class))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\File"))
+    */
     private $files;
 
     #[ORM\ManyToMany(targetEntity: Tag::class, mappedBy: 'messages')]
     #[Groups(['read_message', 'write_message'])]
-    #[OA\Property(type: 'array', items: new OA\Items(type: Tag::class))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\Tag"))
+    */
     private $tags;
 
     #[ORM\OneToMany(mappedBy: 'message', targetEntity: Reaction::class, cascade: ['remove'], orphanRemoval: true)]
     #[Groups(['read_message', 'write_message'])]
-    #[OA\Property(type: 'array', items: new OA\Items(type: Reaction::class))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\Reaction"))
+    */
     private Collection $reactions;
 
     #[ORM\Column(type: 'integer')]
     #[Assert\NotNull]
     #[Assert\Type('integer')]
     #[Groups(['read_message', 'read_message_preview'])]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private $lastActivityDate;
 
     #[ORM\ManyToOne(targetEntity: File::class)]
     #[ORM\JoinColumn(name: 'preview_id', referencedColumnName: 'id')]
     #[Groups(['read_message', 'read_message_preview'])]
-    #[OA\Property(type: File::class)]
+    /**
+     * @ORM\ManyToOne(targetEntity="App\Entity\File")
+     */
     private $preview;
 
     #[ORM\Column(type: 'guid', unique: true)]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private $secretKey;
 
     #[ORM\Column(type: 'boolean')]
     #[Assert\NotNull]
     #[Groups(['read_message'])]
-    #[OA\Property(type: 'boolean')]
+    /**
+     * @OA\Property(type="boolean")
+     */
     private $isInFront;
 
     #[ORM\OneToMany(mappedBy: 'message', targetEntity: Bookmark::class)]
-    #[OA\Property(type: 'array', items: new OA\Items(type: Bookmark::class))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\Bookmark"))
+    */
     private $bookmarks;
 
     #[ORM\Column(type: 'string')]
     #[Assert\NotNull]
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
-    private $type;
+    /**
+     * @OA\Property(type="string")
+     */    private $type;
 
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private $entityType;
 
     #[ORM\Column(type: 'integer', nullable: true)]

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -217,4 +217,9 @@ class Notification extends ApiEntity
     {
         $this->fromMessage = $fromMessage;
     }
+    
+    public function getEntityType(): string
+    {
+        return strtolower((new \ReflectionClass($this))->getShortName());
+    }
 }

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -217,7 +217,7 @@ class Notification extends ApiEntity
     {
         $this->fromMessage = $fromMessage;
     }
-    
+
     public function getEntityType(): string
     {
         return strtolower((new \ReflectionClass($this))->getShortName());

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -24,74 +24,100 @@ class Notification extends ApiEntity
     #[ORM\Column(type: 'guid')]
     #[Groups(['read_notification'])]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private string $id;
 
     #[ORM\Column(type: 'integer')]
     #[Groups(['read_notification'])]
     #[Assert\Type('integer')]
     #[Assert\NotNull]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private int $createdAt;
 
     #[ORM\Column(type: 'string')]
     #[Groups(['read_notification'])]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $type;
 
     #[ORM\Column(type: 'guid', unique: true)]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private string $secretKey;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'notifications')]
     #[ORM\JoinColumn(name: 'owner_id', referencedColumnName: 'id')]
-    #[OA\Property(type: User::class)]
+    /**
+     * @OA\Property(type="App\Entity\User")
+     */
     private ?User $owner = null;
 
     #[ORM\ManyToOne(targetEntity: File::class)]
     #[ORM\JoinColumn(name: 'miniature_id', referencedColumnName: 'id')]
     #[Groups(['read_notification'])]
-    #[OA\Property(type: File::class)]
+    /**
+     * @OA\Property(type="App\Entity\File")
+     */
     private ?File $miniature = null;
 
     #[ORM\Column(type: 'string')]
     #[Groups(['read_notification'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $target;
 
     #[ORM\Column(type: 'boolean')]
     #[Groups(['read_notification'])]
-    #[OA\Property(type: 'boolean')]
+    /**
+     * @OA\Property(type="boolean")
+     */
     private bool $read;
 
     #[ORM\Column(type: 'json', nullable: true)]
     #[Groups(['read_notification'])]
     #[Assert\NotBlank]
-    #[OA\Property(type: 'object')]
+    /**
+     * @OA\Property(type="object")
+     */
     private ?array $data = [];
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(name: 'from_user_id', referencedColumnName: 'id')]
     #[Groups(['read_notification'])]
-    #[OA\Property(type: User::class)]
+    /**
+     * @OA\Property(type="App\Entity\User")
+     */
     private ?User $fromUser = null;
 
     #[ORM\ManyToOne(targetEntity: Group::class)]
     #[ORM\JoinColumn(name: 'from_group_id', referencedColumnName: 'id')]
     #[Groups(['read_notification'])]
-    #[OA\Property(type: Group::class)]
+    /**
+     * @OA\Property(type="App\Entity\Group")
+     */
     private ?Group $fromGroup = null;
 
     #[ORM\ManyToOne(targetEntity: Message::class)]
     #[ORM\JoinColumn(name: 'from_message_id', referencedColumnName: 'id')]
     #[Groups(['read_notification'])]
-    #[OA\Property(type: Message::class)]
+    /**
+     * @OA\Property(type="App\Entity\Message")
+     */
     private ?Message $fromMessage = null;
 
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $entityType;
 
     public function __construct()

--- a/api/src/Entity/Reaction.php
+++ b/api/src/Entity/Reaction.php
@@ -16,30 +16,40 @@ class Reaction extends ApiEntity
     #[ORM\Column(type: 'guid')]
     #[Assert\NotBlank]
     #[Groups(['public'])]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */
     private string $id;
 
     #[ORM\Column(type: 'integer')]
     #[Assert\NotNull]
     #[Assert\Type('integer')]
     #[Groups(['read_reaction'])]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private int $createdAt;
 
     #[ORM\Column(type: 'string')]
     #[Assert\NotBlank]
     #[Groups(['read_reaction'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $value;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'reactions')]
     #[Groups(['public'])]
-    #[OA\Property(type: 'array', items: new OA\Items(type: 'App\Entity\User'))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\User"))
+    */
     private ?User $author = null;
 
     #[ORM\ManyToOne(targetEntity: Message::class, inversedBy: 'reactions')]
     #[Groups(['read_reaction'])]
-    #[OA\Property(type: 'App\Entity\Message')]
+    /**
+     * @OA\Property(type="App\Entity\Message")
+     */
     private Message $message;
 
     public function getEntityType(): string

--- a/api/src/Entity/Tag.php
+++ b/api/src/Entity/Tag.php
@@ -20,7 +20,7 @@ class Tag extends ApiEntity
     #[Groups(['public'])]
     /**
      * @OA\Property(type="guid")
-     */    
+     */
     private string $id;
 
     #[ORM\Column(type: 'integer')]

--- a/api/src/Entity/Tag.php
+++ b/api/src/Entity/Tag.php
@@ -18,35 +18,47 @@ class Tag extends ApiEntity
     #[ORM\Column(type: 'guid')]
     #[Assert\NotBlank]
     #[Groups(['public'])]
-    #[OA\Property(type: 'guid')]
+    /**
+     * @OA\Property(type="guid")
+     */    
     private string $id;
 
     #[ORM\Column(type: 'integer')]
     #[Assert\NotNull]
     #[Assert\Type('integer')]
     #[Groups(['public'])]
-    #[OA\Property(type: 'integer')]
+    /**
+     * @OA\Property(type="integer")
+     */
     private int $createdAt;
 
     #[ORM\ManyToOne(targetEntity: Group::class, inversedBy: 'tags')]
     #[Assert\NotNull]
     #[Groups(['public'])]
-    #[OA\Property(type: 'App\Entity\Group')]
+    /**
+     * @OA\Property(type="App\Entity\Group")
+     */
     private Group $group;
 
     #[ORM\ManyToMany(targetEntity: Message::class, inversedBy: 'tags')]
     #[ORM\JoinTable(name: 'tags_messages')]
-    #[OA\Property(type: 'array', items: new OA\Items(type: 'App\Entity\Message'))]
+    /**
+    * @OA\Property(type="array", @OA\Items(type="App\Entity\Message"))
+    */
     private Collection $messages;
 
     #[ORM\Column(type: 'string')]
     #[Assert\NotBlank]
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private string $name;
 
     #[Groups(['public'])]
-    #[OA\Property(type: 'string')]
+    /**
+     * @OA\Property(type="string")
+     */
     private ?string $entityType = null;
 
     public function __construct()


### PR DESCRIPTION
Various fixes to resolve failed tests as follows:
- Restored getter methods accidentally deleted
- Restored getMiniature step that actually returned the miniature if not already cached
- Adjusted for SQL call that uses Doctrine function that no longer exists

Also adds steps in Initialize command (zusam:init) that syncs database metadata then marks all migration as complete to get into the correct state.