### PR TITLE
Fix notifications

### DIFF
--- a/api/migrations/Version20250801090704.php
+++ b/api/migrations/Version20250801090704.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801090704 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove all notifications that reference users, messages, file, or groups that don\'t exist anymore';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            DELETE FROM `notification`
+            WHERE `owner_id` IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM `user` WHERE `user`.id = `notification`.owner_id
+              )
+        ');
+
+        $this->addSql('
+            DELETE FROM `notification`
+            WHERE `miniature_id` IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM `file` WHERE `file`.id = `notification`.miniature_id
+              )
+        ');
+
+        $this->addSql('
+            DELETE FROM `notification`
+            WHERE `from_user_id` IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM `user` WHERE `user`.id = `notification`.from_user_id
+              )
+        ');
+
+        $this->addSql('
+            DELETE FROM `notification`
+            WHERE `from_group_id` IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM `group` WHERE `group`.id = `notification`.from_group_id
+              )
+        ');
+
+        $this->addSql('
+            DELETE FROM `notification`
+            WHERE `from_message_id` IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM `message` WHERE `message`.id = `notification`.from_message_id
+              )
+        ');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException(
+            'This migration permanently deletes orphaned notifications and cannot be reversed.'
+        );
+    }
+}

--- a/api/src/Controller/User/Delete.php
+++ b/api/src/Controller/User/Delete.php
@@ -13,14 +13,18 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Serializer\SerializerInterface;
+use App\Service\User as UserService;
 
 class Delete extends ApiController
 {
+    private UserService $us;
     public function __construct(
         EntityManagerInterface $em,
-        SerializerInterface $serializer
+        SerializerInterface $serializer,
+        UserService $us
     ) {
         parent::__construct($em, $serializer);
+        $this->us = $us;
     }
 
     /**
@@ -49,9 +53,7 @@ class Delete extends ApiController
 
         $currentUser->setLastActivityDate(time());
         $this->em->persist($currentUser);
-        $this->em->remove($user);
-        $this->em->flush();
-
+        $this->us->delete($user);
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
 }

--- a/api/src/Service/Notification.php
+++ b/api/src/Service/Notification.php
@@ -95,7 +95,8 @@ class Notification
         return $notif;
     }
 
-    public function delete(NotificationEntity $notification) {
+    public function delete(NotificationEntity $notification)
+    {
         $this->em->remove($notification);
         $this->em->flush();
     }

--- a/api/src/Service/Notification.php
+++ b/api/src/Service/Notification.php
@@ -94,4 +94,9 @@ class Notification
 
         return $notif;
     }
+
+    public function delete(NotificationEntity $notification) {
+        $this->em->remove($notification);
+        $this->em->flush();
+    }
 }

--- a/api/src/Service/User.php
+++ b/api/src/Service/User.php
@@ -2,6 +2,8 @@
 
 namespace App\Service;
 
+use App\Entity\Notification as NotificationEntity;
+use App\Service\Notification as NotificationService;
 use App\Entity\User as UserEntity;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -10,13 +12,16 @@ class User
 {
     private $em;
     private $hasher;
+    private NotificationService $notificationService;
 
     public function __construct(
         EntityManagerInterface $em,
-        UserPasswordHasherInterface $hasher
+        UserPasswordHasherInterface $hasher,
+        NotificationService $notificationService
     ) {
         $this->em = $em;
         $this->hasher = $hasher;
+        $this->notificationService = $notificationService;
     }
 
     public function getByLogin($login)
@@ -54,5 +59,18 @@ class User
         $this->em->flush();
 
         return $user;
+    }
+
+    public function delete(UserEntity $user){
+        $notifications = $this->em->getRepository(NotificationEntity::class)->findBy(['owner' => $user,]);
+        foreach ($notifications as $notification) {
+                $this->notificationService->delete($notification);
+        }
+        $notifications = $this->em->getRepository(NotificationEntity::class)->findBy(['fromUser' => $user,]);
+        foreach ($notifications as $notification) {
+                $this->notificationService->delete($notification);
+        }
+        $this->em->remove($user);
+        $this->em->flush();
     }
 }

--- a/api/src/Service/User.php
+++ b/api/src/Service/User.php
@@ -61,14 +61,15 @@ class User
         return $user;
     }
 
-    public function delete(UserEntity $user){
+    public function delete(UserEntity $user)
+    {
         $notifications = $this->em->getRepository(NotificationEntity::class)->findBy(['owner' => $user,]);
         foreach ($notifications as $notification) {
-                $this->notificationService->delete($notification);
+            $this->notificationService->delete($notification);
         }
         $notifications = $this->em->getRepository(NotificationEntity::class)->findBy(['fromUser' => $user,]);
         foreach ($notifications as $notification) {
-                $this->notificationService->delete($notification);
+            $this->notificationService->delete($notification);
         }
         $this->em->remove($user);
         $this->em->flush();

--- a/api/tests/Service/UserTest.php
+++ b/api/tests/Service/UserTest.php
@@ -3,7 +3,9 @@
 namespace App\Tests\Service;
 
 use App\Service\User;
+use App\Service\Notification as NotificationService;
 use App\Entity\User as UserEntity;
+use App\Entity\Notification as NotificationEntity;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -12,6 +14,7 @@ class UserTest extends KernelTestCase
 {
     private $entityManager;
     private $passwordHasher;
+    private $notificationService;
 
     protected function setUp(): void
     {
@@ -19,9 +22,12 @@ class UserTest extends KernelTestCase
 
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
 
-         // Create the schema for the User entity
+        // Create the schema for User and Notification entities
         $schemaTool = new SchemaTool($this->entityManager);
-        $metadata = [$this->entityManager->getClassMetadata(UserEntity::class)];
+        $metadata = [
+            $this->entityManager->getClassMetadata(UserEntity::class),
+            $this->entityManager->getClassMetadata(NotificationEntity::class),
+        ];
         $schemaTool->dropSchema($metadata);
         $schemaTool->createSchema($metadata);
 
@@ -29,6 +35,9 @@ class UserTest extends KernelTestCase
         $hasherMock = $this->createMock(UserPasswordHasherInterface::class);
         $hasherMock->method('hashPassword')->willReturn('some_hashed_password');
         $this->passwordHasher = $hasherMock;
+
+        // Create a mock of the Notification Service
+        $this->notificationService = $this->createMock(NotificationService::class);
     }
 
     protected function tearDown(): void
@@ -44,9 +53,45 @@ class UserTest extends KernelTestCase
     {
         $login = 'user1';
         $password = 'password1';
-        $userService = new User($this->entityManager, $this->passwordHasher);
+        $userService = new User($this->entityManager, $this->passwordHasher, $this->notificationService);
         $user = $userService->create($login, $password);
         $this->assertInstanceOf(UserEntity::class, $user);
         $this->assertEquals($login, $user->getLogin());
+    }
+
+    public function testDelete()
+    {
+        // Create user
+        $user = new UserEntity();
+        $user->setLogin('user1');
+        $user->setPassword('password1');
+        $user->setName('Test user');
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        // Create notifications
+        $notification1 = new NotificationEntity();
+        $notification1->setOwner($user);
+        $notification1->setType(NotificationEntity::GROUP_NAME_CHANGE);
+        $notification1->setTarget('');
+        $notification2 = new NotificationEntity();
+        $notification2->setFromUser($user);
+        $notification2->setType(NotificationEntity::USER_JOINED_GROUP);
+        $notification2->setTarget('');
+        $this->entityManager->persist($notification1);
+        $this->entityManager->persist($notification2);
+        $this->entityManager->flush();
+
+        // Expect delete() to be called twice on the NotificationService
+        $this->notificationService
+            ->expects($this->exactly(2))
+            ->method('delete');
+
+        $userService = new User($this->entityManager, $this->passwordHasher, $this->notificationService);
+        $userService->delete($user);
+
+        // Confirm user no longer exists
+        $found = $this->entityManager->getRepository(UserEntity::class)->findOneByLogin('user1');
+        $this->assertNull($found);
     }
 }


### PR DESCRIPTION
This PR adds a migration that removes notifications that have a link to an object that no longer exists.

It also has a new method in the User service to check for and remove notifications when the user is deleted.

Added a unit test to test the delete method.